### PR TITLE
Update iso and checksum to point to current Kali version

### DIFF
--- a/src/base.pkr.hcl
+++ b/src/base.pkr.hcl
@@ -58,8 +58,8 @@ variable "output_directory" {
 }
 
 source "vmware-iso" "base-kali" {
-  iso_url = "https://cdimage.kali.org/kali-2023.4/kali-linux-2023.4-installer-amd64.iso"
-  iso_checksum = "file:https://cdimage.kali.org/kali-2023.4/SHA256SUMS"
+  iso_url = "https://cdimage.kali.org/current/kali-linux-2024.1-installer-amd64.iso"
+  iso_checksum = "file:https://cdimage.kali.org/current/SHA256SUMS"
   shutdown_command = "echo '${var.vm_password}' | sudo -S shutdown -P now"
   output_directory = "${var.output_directory}"
 


### PR DESCRIPTION
## 🗣 Description ##

Updating iso to use the most current Kali version and updating the associated checksum list to compare to.

## 💭 Motivation and context ##

The installation process would fail when trying to install GRUB on older versions of Kali. This issue is fixed on current versions of Kali. 

## 🧪 Testing ##

[ ] The base Kali VM used for MESA will be properly built and functional

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.
