### PR TITLE
wip Changed to run the GUI with SSL

### DIFF
--- a/ansible/mesa-toolkit.yml
+++ b/ansible/mesa-toolkit.yml
@@ -20,6 +20,7 @@
     pip install .
     pip install colorama # TODO: TEMP FIX
     cd mesa_gui
+    openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/C=/ST=/L=/O=/OU=/CN=" # Creates self-signed SSL cert
     python manage.py migrate
     python manage.py loaddata mesa/fixtures/mesajobs.json
     export DJANGO_SUPERUSER_PASSWORD={{ mesa_user_password }}

--- a/ansible/mesa.service.j2
+++ b/ansible/mesa.service.j2
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c '. /opt/MESA-venv/bin/activate && python manage.py runserver --insecure 0.0.0.0:8080'
-ExecStop=/bin/bash -c 'pkill -f "python manage.py runserver"'
+ExecStart=/bin/bash -c '. /opt/MESA-venv/bin/activate && python manage.py runsslserver --certificate cert.pem --key key.pem 0.0.0.0:8080'
+ExecStop=/bin/bash -c 'pkill -f "python manage.py runsslserver"'
 WorkingDirectory={{ vm_tools_source_dir }}/github.com/cisagov/mesa-gui/mesa_gui/
 
 [Install]


### PR DESCRIPTION
** This PR should be blocked until https://github.com/cisagov/mesa-gui/pull/6 is merged successfully. **

Made changes to mesa-toolkit.yml to create a self-signed SSL certificate. I also changed the way the service is created in mesa.service.j2 so that it runs the server in SSL mode using the generated certificate.