### PR TITLE
Moved mesa web app to nginx

### DIFF
--- a/ansible/mesa-toolkit.yml
+++ b/ansible/mesa-toolkit.yml
@@ -19,6 +19,7 @@
     cd {{ vm_tools_source_dir }}/github.com/cisagov/mesa-gui
     pip install .
     pip install colorama # TODO: TEMP FIX
+    pip install gunicorn
     cd mesa_gui
     openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem -days 365 -nodes -subj "/C=/ST=/L=/O=/OU=/CN=" # Creates self-signed SSL cert
     python manage.py migrate
@@ -38,6 +39,22 @@
     path: "{{ vm_tools_source_dir }}/github.com/cisagov/mesa-gui/mesa_gui/mesa_gui/settings.py"
     regexp: '^ALLOWED_HOSTS ='
     line: 'ALLOWED_HOSTS = ["*"]'
+
+- name: Install nginx
+  become: yes
+  apt:
+    name: nginx
+    state: latest
+    update_cache: yes
+
+- name: Copy nginx config file
+  become: yes
+  template:
+    src: nginx.conf.j2
+    dest: /etc/nginx/sites-enabled/default
+    owner: root
+    group: root
+    mode: 0644
 
 - name: Install MESA-Gui as a Service
   template:

--- a/ansible/mesa-toolkit.yml
+++ b/ansible/mesa-toolkit.yml
@@ -27,6 +27,7 @@
     export DJANGO_SUPERUSER_PASSWORD={{ mesa_user_password }}
     export DJANGO_SUPERUSER_EMAIL=vulnerability@cisa.dhs.gov
     python manage.py createsuperuser --username {{ mesa_user_name }} --no-input
+    python manage.py collectstatic --noinput
 
 - name: Disable DEBUG Mode
   lineinfile:

--- a/ansible/mesa.service.j2
+++ b/ansible/mesa.service.j2
@@ -4,8 +4,8 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c '. /opt/MESA-venv/bin/activate && python manage.py runsslserver --certificate cert.pem --key key.pem 0.0.0.0:8080'
-ExecStop=/bin/bash -c 'pkill -f "python manage.py runsslserver"'
+ExecStart=/bin/bash -c '. /opt/MESA-venv/bin/activate && gunicorn --bind 127.0.0.1:8000 mesa_gui.wsgi:application'
+ExecStop=/bin/bash -c 'pkill -f "gunicorn --bind 127.0.0.1:8000 mesa_gui.wsgi:application"'
 WorkingDirectory={{ vm_tools_source_dir }}/github.com/cisagov/mesa-gui/mesa_gui/
 
 [Install]

--- a/ansible/templates/nginx.conf.j2
+++ b/ansible/templates/nginx.conf.j2
@@ -1,0 +1,30 @@
+# HTTP to HTTPS Redirect
+server {
+    listen 80;
+    server_name 127.0.0.1 localhost;
+   
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS Server Block
+server {
+    listen 443 ssl;
+    server_name 127.0.0.1 localhost;
+
+    ssl_certificate /opt/src/github.com/cisagov/mesa-gui/mesa_gui/cert.pem;
+    ssl_certificate_key /opt/src/github.com/cisagov/mesa-gui/mesa_gui/key.pem;
+
+    location /static/ {
+        alias /opt/src/github.com/cisagov/mesa-gui/mesa_gui/static_files/;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/src/base.pkr.hcl
+++ b/src/base.pkr.hcl
@@ -58,7 +58,7 @@ variable "output_directory" {
 }
 
 source "vmware-iso" "base-deb" {
-  iso_url = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.6.0-amd64-netinst.iso"
+  iso_url = "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.7.0-amd64-netinst.iso"
   iso_checksum = "file:https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/SHA256SUMS"
   shutdown_command = "echo '${var.vm_password}' | sudo -S shutdown -P now"
   output_directory = "${var.output_directory}"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR satisfies cisagov/mesa-packer/issues/8

## 💭 Motivation and context ##

Please refer to cisagov/mesa-packer/issues/8

## 🧪 Testing ##

- Added the installation of nginx
- Added the configuration of the `/etc/nginx/sites-enabled/default` file
- Added `pip install gunicorn` to the ansible setup of the MESA toolkit
- Made changes to the mesa.service config file to reflect gunicorn
- Built the packer image and confirmed the availability of the MESA web application on TCP port 443 over HTTPS
- Validated the redirected of http://localhost to https://localhost

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] This repo successfully builds the mesa-deb image
- [x] The MESA web application is available on https://localhost on boot
- [x] The MESA web application functions as expected
